### PR TITLE
🔨Refactor: User 엔티티, UserService 수정

### DIFF
--- a/src/main/java/challenge18/hotdeal/domain/user/entity/User.java
+++ b/src/main/java/challenge18/hotdeal/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity(name = "users")
+@Table(indexes = @Index(name = "idx_userId", columnList = "userId"))
 @NoArgsConstructor
 @Getter
 public class User {

--- a/src/main/java/challenge18/hotdeal/domain/user/service/UserService.java
+++ b/src/main/java/challenge18/hotdeal/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
@@ -25,12 +26,12 @@ public class UserService {
 
 
     // 회원가입
+    @Transactional
     public ResponseEntity<Message> signup(SignupRequest request) {
         UserRole role = UserRole.ROLE_USER;
 
         // 중복 회원 체크
-        Optional<User> user = checkUserExist(request.getUserId());
-        if(user.isPresent()){
+        if (userRepository.findByUserId(request.getUserId()).isPresent()) {
             throw new DuplicateRequestException("중복된 회원이 이미 존재합니다.");
         }
 
@@ -47,6 +48,7 @@ public class UserService {
     }
 
     // 로그인
+    @Transactional
     public ResponseEntity<Message> login(LoginRequest request, HttpServletResponse response) {
         // 회원정보 존재 유무 체크
         Optional<User> user = checkUserExist(request.getUserId());


### PR DESCRIPTION
1. User 엔티티 index 추가
@Table(indexes = @Index(name = "idx_userId", columnList = "userId"))

2. UserService 회원가입 중복확인 체크 수정
메서드를 하나 더 거치지 않고 바로 확인하도록 수정하였습니다.
        Optional<User> user = checkUserExist(request.getUserId());
        if(user.isPresent()){
            throw new DuplicateRequestException("중복된 회원이 이미 존재합니다.");
        }
기존 코드를
if (userRepository.findByUserId(request.getUserId()).isPresent()) {
            throw new DuplicateRequestException("중복된 회원이 이미 존재합니다.");
        }
로 수정하였습니다.